### PR TITLE
fixed the run command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ After installing SCALE-Sim, it can be run by using the ```scalesim.scale``` and 
 The above method uses the installed package for running the simulator.
 In cases where you would like to run directly from the source, the following command should be used instead.
 
-```$PYTHONPATH=$PYTHONPATH:<scale_sim_repo_root> python3 <scale_sim_repo_root>/scalesim/scale.py -c <path_to_config_file> -t <path_to_topology_file>```
+```$ PYTHONPATH=$PYTHONPATH:<scale_sim_repo_root> python3 <scale_sim_repo_root>/scalesim/scale.py -c <path_to_config_file> -t <path_to_topology_file>```
 
 If you are running from sources for the first time and do not have all the dependencies installed, please install them first  using the following command.
 

--- a/README.md
+++ b/README.md
@@ -27,13 +27,17 @@ Getting started is simple! SCALE-Sim is completely written in python and could b
 
 You can install SCALE-Sim in your environment using the following command
 
+```$ pip3 install <path-to-scalesim-v3-folder>```
+
+If you are a developer that will modify scale-sim during your usage, please install it with `-e` flag, which will create a symbolic link instead of replicating scalesim in your environment, thus modification of scale-sim code can be syncronized simultaneously
+
 ```$ pip3 install -e <path-to-scalesim-v3-folder>```
 
 ### *Launching a run*
 
-SCALE-Sim can be run by using the ```scale.py``` script from the repository and providing the paths to the architecture configuration, and the topology descriptor csv file.
+After installing SCALE-Sim, it can be run by using the ```scalesim.scale``` and providing the paths to the architecture configuration, and the topology descriptor csv file.
 
-```$ python3 scale.py -c <path_to_config_file> -t <path_to_topology_file> -p <path_to_output_log_dir>```
+```$ python3 -m scalesim.scale -c <path_to_config_file> -t <path_to_topology_file> -p <path_to_output_log_dir>```
 
 ### *Running from source*
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ After installing SCALE-Sim, it can be run by using the ```scalesim.scale``` and 
 The above method uses the installed package for running the simulator.
 In cases where you would like to run directly from the source, the following command should be used instead.
 
-```$ python3 <scale_sim_repo_root>/scalesim/scale.py -c <path_to_config_file> -t <path_to_topology_file>```
+```$PYTHONPATH=$PYTHONPATH:<scale_sim_repo_root> python3 <scale_sim_repo_root>/scalesim/scale.py -c <path_to_config_file> -t <path_to_topology_file>```
 
 If you are running from sources for the first time and do not have all the dependencies installed, please install them first  using the following command.
 


### PR DESCRIPTION
Purely description changes. No functional changes. Just make things more clear.

In the previous readme, it instruct two ways to run scalesim
1. Install as a package, and run.
2. Run from source.

However, for the first option, even after installing it as a package, the run command of
`python3 scale.py xxxxx` 
is still "running from source" for the file of scale.py from the source, instead of using the scale.py installed in environment. It will have no problem, but somehow duplicated because user don't need to keep the scale-sim source codes after install them. Also if the user get scalesim from pip later, they dont get the file of scale.py at all.

Instead, running
`python3 -m scalesim.scale xxxxx` will run scale.py integrated in the package, which might more aligning.



For the second option, it will not running if user dont pip install the package, nor dont add the source code to the PYTHONPATH in order to make scalesim package reachable.
To resolve this, change the command in the following:
`PYTHONPATH=$PYTHONPATH:<scale_sim_repo_root> python3 <scale_sim_repo_root>/scalesim/scale.py xxx`,
and it will always explicitly add scalesim root to the PYTHONPATH, which makes sure the scalesim package is reachable even user dont pip install it.
